### PR TITLE
Add resilient UUID generator

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteOption, Company, CompanySite, Job, OTRequest, OTRequestInput } from "./types";
-import { calculateOtHours, generateDocumentNumber } from "./utils";
+import { calculateOtHours, generateDocumentNumber, safeRandomUUID } from "./utils";
 
 const companies: Company[] = [
   {
@@ -137,7 +137,7 @@ export const db = {
       throw new Error("Invalid company or job selection");
     }
 
-    const id = crypto.randomUUID();
+    const id = safeRandomUUID();
     const docNo = generateDocumentNumber(company.code, job.jobCode);
     const hours = calculateOtHours(input.startAt, input.endAt);
     const createdAt = new Date().toISOString();
@@ -152,7 +152,7 @@ export const db = {
       createdAt,
       auditLog: [
         {
-          id: crypto.randomUUID(),
+          id: safeRandomUUID(),
           actor: input.employeeEmail,
           action: "submitted",
           meta: {
@@ -186,7 +186,7 @@ export const db = {
     request.auditLog = [
       ...request.auditLog,
       {
-        id: crypto.randomUUID(),
+        id: safeRandomUUID(),
         actor,
         action: status,
         meta: { reason },

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,6 +1,6 @@
-import crypto from "node:crypto";
 import { addHours, isAfter } from "date-fns";
 import type { ApprovalToken } from "./types";
+import { safeRandomUUID } from "./utils";
 
 const tokens = new Map<string, ApprovalToken>();
 
@@ -9,10 +9,10 @@ export function createApprovalTokens(requestId: string): ApprovalToken[] {
   const created: ApprovalToken[] = [];
   for (const action of actions) {
     const token: ApprovalToken = {
-      id: crypto.randomUUID(),
+      id: safeRandomUUID(),
       requestId,
       action,
-      token: crypto.randomUUID(),
+      token: safeRandomUUID(),
       expiresAt: addHours(new Date(), 72).toISOString(),
       usedAt: null,
     };


### PR DESCRIPTION
## Summary
- add a shared `safeRandomUUID` helper that falls back to manual v4 generation when the Web Crypto API is unavailable
- update OT request persistence and approval token creation to rely on the resilient UUID helper instead of direct `crypto.randomUUID`

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5012eb390832aba845a9949e8dcc6