### PR TITLE
Fix headlessui import optimization runtime error

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
-    optimizePackageImports: ["lucide-react", "@headlessui/react"],
+    optimizePackageImports: ["lucide-react"],
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- remove `@headlessui/react` from Next.js optimizePackageImports to avoid runtime TypeError

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5196ff1a8832aaa0becc406ae1e59