### PR TITLE
Fix profile state type to allow array entries

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -12,9 +12,7 @@ export default function ProfilePage() {
   const [jobName, setJobName] = useState("");
   const [companySaved, setCompanySaved] = useState(false);
   const [jobSaved, setJobSaved] = useState(false);
-  const [companies, setCompanies] = useState<
-    { name: string; code: string; hrEmail: string }
-  >([]);
+  const [companies, setCompanies] = useState<{ name: string; code: string; hrEmail: string }[]>([]);
   const [jobs, setJobs] = useState<{ id: string; name: string }[]>([]);
 
   const handleCompanySubmit = (event: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## Summary
- correct the profile page company list state to use an array type so company submissions append correctly

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d524e35f0c832aa7568867ab25ac0b